### PR TITLE
IRateProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ freshness of the data. These contracts have not been formally audited for securi
 
 ## Usage
 
-Calling `rate()` on `RocketOvmPriceOracle` will return the latest rETH exchange rate reported. This value is in the form
-of the ETH value of 1 rETH. e.g. If 1 rETH is worth 1.5 ETH `rate()` will return 1.5e18. `lastUpdated()` can be called to
+Calling `getRate()` on `RocketOvmPriceOracle` will return the latest rETH exchange rate reported. This value is in the form
+of the ETH value of 1 rETH. e.g. If 1 rETH is worth 1.5 ETH `getRate()` will return 1.5e18. `getLastUpdated()` can be called to
 retrieve the timestamp that the rate was last updated.
 
 ## Deployments
@@ -23,4 +23,28 @@ integration testing before promotion to mainnet.
 | Chain | RocketOvmPriceMessenger (EVM) | RocketOvmPriceOracle (OVM) |
 | -- | -- | -- |
 | Mainnet | tba | tba |
-| Goerli | 0x87E2deCE7d0A080D579f63cbcD7e1629BEcd7E7d | 0xc6307a58556FDcF93255ad541dccacCC10b75eA4 |
+| Goerli | 0x3bF13C170a664e0CeAB1E878669F1Ef5A65280b5 | 0x96a6da00d79C6fa355B9D9f5b49488310E84D3a1 |
+
+### Goerli
+
+```
+export RPC_OPTIMISM=https://goerli.optimism.io
+export RPC_ETHEREUM=https://xxx
+export PRIVATE_KEY=xxx
+export ETHERSCAN_API_KEY=xxx
+
+forge create \
+  --legacy \
+  --rpc-url $RPC_OPTIMISM \
+  --private-key $PRIVATE_KEY \
+  src/RocketOvmPriceOracle.sol:RocketOvmPriceOracle \
+  --constructor-args 0x4200000000000000000000000000000000000007
+
+forge create \
+  --rpc-url $RPC_ETHEREUM \
+  --private-key $PRIVATE_KEY \
+  src/RocketOvmPriceMessenger.sol:RocketOvmPriceMessenger \
+  --constructor-args 0xd8cd47263414afeca62d6e2a3917d6600abdceb3 0x96a6da00d79C6fa355B9D9f5b49488310E84D3a1 0x5086d1eef304eb5284a0f6720f79403b4e9be294 \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --verify
+```

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']

--- a/src/RocketOvmPriceOracle.sol
+++ b/src/RocketOvmPriceOracle.sol
@@ -3,33 +3,51 @@ pragma solidity ^0.8.13;
 
 import "@eth-optimism/contracts/libraries/bridge/ICrossDomainMessenger.sol";
 
+interface IRateProvider {
+    /**
+     * @dev Returns an 18 decimal fixed point number that is the exchange rate of the token to some other underlying
+     * token. The meaning of this rate depends on the context.
+     */
+    function getRate() external view returns (uint256);
+}
+
 /// @author Kane Wallmann (Rocket Pool)
 /// @notice Receives updates from L1 on the canonical rETH exchange rate
-contract RocketOvmPriceOracle {
+contract RocketOvmPriceOracle is IRateProvider {
     // Events
     event RateUpdated(uint256 rate);
 
     // Immutables
     ICrossDomainMessenger immutable ovmL2CrossDomainMessenger;
 
-    /// @notice The rETH exchange rate in the form of how much ETH 1 rETH is worth
-    uint256 public rate;
-
-    /// @notice The timestamp of the block in which the rate was last updated
-    uint256 public lastUpdated;
-
-    /// @notice Set to the contract on L1 that has permission to update the rate
-    address public owner;
+    uint256 rate;
+    uint256 lastUpdated;
+    address owner;
 
     constructor(address _l2CrossDomainMessenger) {
         ovmL2CrossDomainMessenger = ICrossDomainMessenger(_l2CrossDomainMessenger);
         owner = msg.sender;
     }
 
+    /// @notice Set to the contract on L1 that has permission to update the rate
+    function getOwner() external view returns (address) {
+        return owner;
+    }
+
     /// @notice Hands ownership to the L1 price messenger contract
     function setOwner(address _newOwner) external {
         require(msg.sender == owner, "Only owner");
         owner = _newOwner;
+    }
+
+    /// @notice The timestamp of the block in which the rate was last updated
+    function getLastUpdated() external view returns (uint256) {
+        return lastUpdated;
+    }
+
+    /// @notice The rETH exchange rate in the form of how much ETH 1 rETH is worth
+    function getRate() external view returns (uint256) {
+        return rate;
     }
 
     /// @notice Called by the messenger contract on L1 to update the exchange rate

--- a/test/RocketPriceOracle.t.sol
+++ b/test/RocketPriceOracle.t.sol
@@ -45,8 +45,8 @@ contract RocketPriceOracleTest is Test {
             ovmL1CrossDomainMessenger
         );
         // Rate and last updated should be 0
-        uint256 rate = priceOracle.rate();
-        uint256 updated = priceOracle.lastUpdated();
+        uint256 rate = priceOracle.getRate();
+        uint256 updated = priceOracle.getLastUpdated();
         assertEq(updated, 0);
         assertEq(rate, 0);
     }
@@ -58,7 +58,7 @@ contract RocketPriceOracleTest is Test {
 
     function testOnlyOwnerCanSetOwner() public {
         priceOracle.setOwner(address(priceMessenger));
-        assertEq(priceOracle.owner(), address(priceMessenger));
+        assertEq(priceOracle.getOwner(), address(priceMessenger));
     }
 
     function testRateStale() public {
@@ -87,8 +87,8 @@ contract RocketPriceOracleTest is Test {
         // Send the updated rate
         priceMessenger.submitRate();
         // Check rate and lastUpdated were updated
-        uint256 rate = priceOracle.rate();
-        uint256 updated = priceOracle.lastUpdated();
+        uint256 rate = priceOracle.getRate();
+        uint256 updated = priceOracle.getLastUpdated();
         assertGt(updated, 0);
         assertEq(rate, 1 ether);
     }
@@ -97,8 +97,8 @@ contract RocketPriceOracleTest is Test {
         // Send the updated rate
         priceMessenger.submitRate();
         // Rate should not be updated
-        uint256 rate = priceOracle.rate();
-        uint256 updated = priceOracle.lastUpdated();
+        uint256 rate = priceOracle.getRate();
+        uint256 updated = priceOracle.getLastUpdated();
         assertEq(updated, 0);
         assertEq(rate, 0);
     }
@@ -124,7 +124,7 @@ contract RocketPriceOracleTest is Test {
         // Send the updated rate
         priceMessenger.submitRate();
         // Check rate and lastUpdated were updated
-        uint256 rate = priceOracle.rate();
+        uint256 rate = priceOracle.getRate();
         assertEq(rate, expectedRate);
     }
 }


### PR DESCRIPTION
Makes it compatible with https://github.com/balancer-labs/balancer-v2-monorepo/blob/master/pkg/interfaces/contracts/pool-utils/IRateProvider.sol

```solidity
interface IRateProvider {
    function getRate() external view returns (uint256);
}
```

I tried adding the repo as a dependency and importing the interface but everything broke because of `pragma solidity ^0.7.0;`

# Foundry

## `foundry.toml`

It complained that `default` is deprecated and `forge config --fix` made these changes.

## `forge test`

```
Running 6 tests for test/RocketPriceOracle.t.sol:RocketPriceOracleTest
[PASS] testCanSendRate() (gas: 110284)
[PASS] testFailOnlyOwnerCanSetOwner() (gas: 12591)
[PASS] testNotOwner() (gas: 60855)
[PASS] testOnlyOwnerCanSetOwner() (gas: 13775)
[PASS] testRateStale() (gas: 119520)
[PASS] testRates(uint256,uint256) (runs: 256, μ: 105724, ~: 119409)
Test result: ok. 6 passed; 0 failed; finished in 166.85ms
```

# Contracts

https://goerli.etherscan.io/address/0x3bf13c170a664e0ceab1e878669f1ef5a65280b5

https://blockscout.com/optimism/goerli/address/0x96a6da00d79C6fa355B9D9f5b49488310E84D3a1/ (times out and I can't verify the contract)